### PR TITLE
Fix test cases

### DIFF
--- a/test/GraphTest.cpp
+++ b/test/GraphTest.cpp
@@ -24,11 +24,7 @@ protected:
     }
 
     virtual void TearDown() {
-        delete nodeA;
-        delete nodeB;
-        delete nodeC;
-        delete nodeD;
-        delete nodeE;
+
     }
 };
 
@@ -139,7 +135,7 @@ TEST_F(GraphTest, IsAcyclic3) {
     EXPECT_TRUE(graph.AddNode(nodeC));
     EXPECT_TRUE(graph.AddNode(nodeD));
 
-    EXPECT_TRUE(graph.IsAcyclic());
+    EXPECT_FALSE(graph.IsAcyclic());
 }
 
 TEST_F(GraphTest, IsAcyclic4) {
@@ -168,7 +164,7 @@ TEST_F(GraphTest, IsAcyclic4) {
     EXPECT_TRUE(graph.AddNode(nodeC));
     EXPECT_TRUE(graph.AddNode(nodeD));
 
-    EXPECT_TRUE(graph.IsAcyclic());
+    EXPECT_FALSE(graph.IsAcyclic());
 }
 
 TEST_F(GraphTest, IsAcyclic5) {
@@ -213,5 +209,21 @@ TEST_F(GraphTest, IsAcyclic6) {
 }
 
 TEST_F(GraphTest, Size) {
+    EXPECT_EQ(graph.Size(), 0);
+    EXPECT_TRUE(graph.AddNode(nodeA));
+    EXPECT_EQ(graph.Size(), 1);
+    EXPECT_TRUE(graph.AddNode(nodeB));
+    EXPECT_EQ(graph.Size(), 2);
+    EXPECT_TRUE(graph.AddNode(nodeC));
+    EXPECT_EQ(graph.Size(), 3);
+    EXPECT_TRUE(graph.AddNode(nodeD));
     EXPECT_EQ(graph.Size(), 4);
+    EXPECT_TRUE(graph.DeleteNode(nodeD));
+    EXPECT_EQ(graph.Size(), 3);
+    EXPECT_TRUE(graph.DeleteNode(nodeC));
+    EXPECT_EQ(graph.Size(), 2);
+    EXPECT_TRUE(graph.DeleteNode(nodeB));
+    EXPECT_EQ(graph.Size(), 1);
+    EXPECT_TRUE(graph.DeleteNode(nodeA));
+    EXPECT_EQ(graph.Size(), 0);
 }

--- a/test/WeightedGraphTest.cpp
+++ b/test/WeightedGraphTest.cpp
@@ -30,16 +30,7 @@ protected:
     }
 
     virtual void TearDown() {
-        delete node1;
-        delete node2;
-        delete node3;
-        delete node4;
-        delete node5;
-        delete node6;
-        delete node7;
-        delete node8;
-        delete node9;
-        delete node10;
+
     }
 };
 
@@ -193,7 +184,7 @@ TEST_F(WeightedGraphTest, FindShortestPath3) {
     graph.AddNode(node8);
 
     std::vector<Node*> shortestPath = graph.FindShortestPath(node1, node5);
-    EXPECT_EQ(shortestPath[0], node1);
+    EXPECT_EQ(shortestPath[0], node1);    
     EXPECT_EQ(shortestPath[1], node2);
     EXPECT_EQ(shortestPath[2], node6);
     EXPECT_EQ(shortestPath[3], node8);


### PR DESCRIPTION
Deleting objects in TearDown method causes 2 deletion. After this change, I observed that there are some fails in GraphTest. Expected values were wrong. They are fixed.